### PR TITLE
define and use customized original error

### DIFF
--- a/go/domain/errors/code.go
+++ b/go/domain/errors/code.go
@@ -1,0 +1,10 @@
+package errors
+
+type DDDGuysErrorCode uint
+
+const (
+	NoError = iota
+	UserIdError
+	UserNameError
+	Unknown
+)

--- a/go/domain/errors/error.go
+++ b/go/domain/errors/error.go
@@ -1,0 +1,32 @@
+package errors
+
+import "fmt"
+
+type DDDGuysError struct {
+	message string
+	code    DDDGuysErrorCode
+}
+
+func New(message string, code DDDGuysErrorCode) *DDDGuysError {
+	return &DDDGuysError{message, code}
+}
+
+func (e DDDGuysError) Error() string {
+	return fmt.Sprintf(`%s with error code: %d`, e.message, e.code)
+}
+
+func (e DDDGuysError) Code() DDDGuysErrorCode {
+	return e.code
+}
+
+func Code(err error) DDDGuysErrorCode {
+	if err == nil {
+		return NoError
+	}
+	if customError, ok := err.(interface {
+		Code() DDDGuysErrorCode
+	}); ok {
+		return customError.Code()
+	}
+	return Unknown
+}

--- a/go/domain/model/user/name.go
+++ b/go/domain/model/user/name.go
@@ -1,7 +1,7 @@
 package user
 
 import (
-	"errors"
+	"github.com/jupemara/ddd-guys/go/domain/errors"
 )
 
 type Name struct {
@@ -15,7 +15,10 @@ func NewName(firstName string, lastName string) (*Name, error) {
 		len(lastName) < 1,
 	} {
 		if v {
-			return nil, errors.New("assertion error")
+			return nil, errors.New(
+				"user name error",
+				errors.UserNameError,
+			)
 		}
 	}
 	return &Name{firstName, lastName}, nil

--- a/go/go.sum
+++ b/go/go.sum
@@ -52,6 +52,7 @@ github.com/jupemara/ddd-guys v0.0.0-20200129083116-056407f402a0 h1:ZMjxKKYijo+5k
 github.com/jupemara/ddd-guys v0.0.0-20200222190200-c4acbfbf90d9 h1:i8xbzjLiuaSLP+BSPEPWyOQiSFVK0paskWMdNIQpeR8=
 github.com/jupemara/ddd-guys v0.0.0-20200303115535-ae5279caac78 h1:Qc501Q0bnNBgFlGRb8/AcxQ0aOqROiVl0AjfeX+YyD4=
 github.com/jupemara/ddd-guys v0.0.0-20200304153639-7036e11828de h1:9u2diqljhkdZCzw+eSEibpoAzkAqHsa0rODeLPzlKYU=
+github.com/jupemara/ddd-guys v0.0.0-20200308132419-4cc33561da76 h1:rlNug+hoFRR2Q8ogun0xjqGoqVthqTRELjuZZsqACn8=
 github.com/jupemara/ddd-guys/go v0.0.0-20200222190200-c4acbfbf90d9/go.mod h1:s6qaiS87a2LgP4/YD82iWBicm3cj3CDLoO2l5jaRAQM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
- 独自エラー型を作る
  - といってもエラーのinterfaceは `type Error interfae {Error() string}` というとてもシンプルなもの
- 独自のエラーコードを定義する(iota使ってます)
- ドメイン層からは独自定義エラーを返す(もちろん、最終的にはapllication serviceも独自定義エラーを返す)
- 最終的にcontrollerのレイヤーで "map[DDDGuysErrorCode]string" なメッセージとのマッピングを作ってそれをメッセージとして返してあげる

```golang
HTTPJpErrorMessageMap= map[DDDGuysErrorCode]string{
  errors.UserNameError: "ユーザの姓、名は最低1文字を入力必要があります",
}
```

みたいな形で定義すれば、HTTPのエラーメッセージとしてそのまま返ってきたエラーからエラーコードを取得してマッピングから取得して返せる。