### PR TITLE
add test cases for user update usecase

### DIFF
--- a/go/usecase/user/update_test.go
+++ b/go/usecase/user/update_test.go
@@ -1,6 +1,7 @@
 package user_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,21 +20,56 @@ func TestUserUpdateUsecase(t *testing.T) {
 
 var _ = Describe("UseUpdateUsecase", func() {
 	var (
-		ctrl       *gomock.Controller
-		repository domain.IUserRepository
-		usecase    *user.UserUpdateUsecase
+		ctrl         *gomock.Controller
+		repository   *mock.MockIUserRepository
+		usecase      *user.UserUpdateUsecase
+		existingUser *domain.User
 	)
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		repository = mock.NewMockIUserRepository(ctrl)
 		usecase = user.NewUserUpdateUsecase(repository)
+		existingUser, _ = domain.NewUser(domain.NewId("12345"), "Rob", "Pike")
 	})
 	AfterEach(func() {
 		ctrl.Finish()
 	})
 	Describe("#Execute", func() {
-		Context("with valid name", func() {})
-		Context("with empty first name", func() {})
-		Context("when repository occur unexpected error", func() {})
+		Context("with valid name", func() {
+			It("updates an User without error", func() {
+				command := user.NewCommand("12345", "Ken", "Thompson")
+				repository.EXPECT().FindById(gomock.Any()).Return(existingUser, nil).Times(1)
+				repository.EXPECT().Update(gomock.Any()).Return(nil).Times(1)
+				err := usecase.Execute(command)
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("with empty first name and valid last name", func() {
+			It("updates an User without error", func() {
+				command := user.NewCommand("12345", "", "Thompson")
+				repository.EXPECT().FindById(gomock.Any()).Return(existingUser, nil).Times(1)
+				repository.EXPECT().Update(gomock.Any()).Return(nil).Times(1)
+				err := usecase.Execute(command)
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("with empty first/last name", func() {
+			It("does not update User with no error", func() {
+				command := user.NewCommand("12345", "", "")
+				repository.EXPECT().FindById(gomock.Any()).Return(existingUser, nil).Times(1)
+				repository.EXPECT().Update(gomock.Any()).Return(nil).Times(0)
+				err := usecase.Execute(command)
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("when repository occur unexpected error", func() {
+			It("fails with error when executing FindById()", func() {
+				command := user.NewCommand("12345", "Ken", "Thompson")
+				repository.EXPECT().FindById(gomock.Any()).Return(nil, errors.New("unexpected error")).Times(1)
+				repository.EXPECT().Update(gomock.Any()).Return(nil).Times(0)
+				err := usecase.Execute(command)
+				Expect(err).NotTo(BeNil())
+			})
+		})
 	})
 })

--- a/go/usecase/user/update_test.go
+++ b/go/usecase/user/update_test.go
@@ -29,7 +29,10 @@ var _ = Describe("UseUpdateUsecase", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		repository = mock.NewMockIUserRepository(ctrl)
 		usecase = user.NewUserUpdateUsecase(repository)
-		existingUser, _ = domain.NewUser(domain.NewId("12345"), "Rob", "Pike")
+
+		var err error
+		existingUser, err = domain.NewUser(domain.NewId("12345"), "Rob", "Pike")
+		Expect(err).To(BeNil())
 	})
 	AfterEach(func() {
 		ctrl.Finish()
@@ -57,6 +60,7 @@ var _ = Describe("UseUpdateUsecase", func() {
 			It("does not update User with no error", func() {
 				command := user.NewCommand("12345", "", "")
 				repository.EXPECT().FindById(gomock.Any()).Return(existingUser, nil).Times(1)
+				// First name, Last name が empty の場合、更新対象なしとみなされ Update は呼ばれない
 				repository.EXPECT().Update(gomock.Any()).Return(nil).Times(0)
 				err := usecase.Execute(command)
 				Expect(err).To(BeNil())
@@ -66,6 +70,7 @@ var _ = Describe("UseUpdateUsecase", func() {
 			It("fails with error when executing FindById()", func() {
 				command := user.NewCommand("12345", "Ken", "Thompson")
 				repository.EXPECT().FindById(gomock.Any()).Return(nil, errors.New("unexpected error")).Times(1)
+				// FindById でエラーが発生した場合、後続の Update は呼ばれない
 				repository.EXPECT().Update(gomock.Any()).Return(nil).Times(0)
 				err := usecase.Execute(command)
 				Expect(err).NotTo(BeNil())


### PR DESCRIPTION
User update の usecase に テストケースを追加してみました。

Firstname or Lastname に empty string を渡して更新した場合、エラーが発生するかと思っていたのですが、Usecase の実装では、その場合、更新対象から外すというという挙動でしたね。。。